### PR TITLE
Update for Laravel 4.2.* & rcrowe/TwigBridge 0.6.*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.phar
 composer.lock
 .DS_Store
+.idea

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     }
   ],
   "require": {
-    "php": ">=5.3.0",
+    "php": ">=5.4.0",
     "illuminate/support": "4.2.x"
   },
   "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "php": ">=5.4.0",
-    "illuminate/support": "4.2.x"
+    "illuminate/support": "4.2.*"
   },
   "suggest": {
     "rcrowe/twigbridge": "Required for Twig support."

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "php": ">=5.3.0",
-    "illuminate/support": "4.1.x"
+    "illuminate/support": "4.2.x"
   },
   "suggest": {
     "rcrowe/twigbridge": "Required for Twig support."

--- a/src/Fojuth/Plupload/TwigExtension.php
+++ b/src/Fojuth/Plupload/TwigExtension.php
@@ -1,47 +1,44 @@
 <?php namespace Fojuth\Plupload;
 
-use TwigBridge\Extension as BaseExtension;
+use Twig_Extension;
+use Twig_SimpleFunction;
 use Illuminate\Foundation\Application;
 use Twig_Environment;
 
-class TwigExtension extends BaseExtension {
+class TwigExtension extends Twig_Extension {
 
-  /**
-   * Returns the name of the extension.
-   *
-   * @return string Extension's name.
-   */
-  public function getName() {
-    return 'PluploadExtension';
-  }
+    /**
+     * Returns the name of the extension.
+     *
+     * @return string Extension's name.
+     */
+    public function getName() {
+        return 'PluploadExtension';
+    }
 
-  /**
-   * @param Illuminate\Foundation\Application $app
-   * @param Twig_Environment                  $twig
-   */
-  public function __construct(Application $app, Twig_Environment $twig) {
-    parent::__construct($app, $twig);
-    
-    $this->registerTwigFunctions();
-  }
+    /**
+     * Registers the Twig functions.
+     */
+    public function getFunctions() {
+        return [
+            new Twig_SimpleFunction(
+                'plupload',
+                function($view = null, $browse_button = null, $prefix = null, $additional_data = array()){
 
-  /**
-   * Registers the Twig functions.
-   */
-  private function registerTwigFunctions() {
-    $this->twig->addFunction('plupload', new \Twig_SimpleFunction('plupload', function($view = null, $browse_button = null, $prefix = null, $additional_data = array()){
-      $view = (true === is_null($view)) ? \Config::get('plupload::plupload.view') : $view;
-      $prefix = (true === is_null($prefix)) ? 'plupload_'.uniqid() : $prefix;
-      $browse_button = (true === is_null($browse_button)) ? $prefix.'_browse' : $browse_button;
-      
-      return \View::make($view, array(
-        'upload_handler' => \Config::get('plupload::plupload.upload_handler'),
-        'browse_button_id' => $browse_button,
-        'prefix' => $prefix,
-        'handler_gate' => \Config::get('plupload::plupload.upload_handler_gate'),
-        'max_file_size' => \Config::get('plupload::plupload.max_file_size'),
-        'additional_data' => $additional_data,
-      ));
-    }));
-  }
+                    $view = (true === is_null($view)) ? \Config::get('plupload::plupload.view') : $view;
+                    $prefix = (true === is_null($prefix)) ? 'plupload_'.uniqid() : $prefix;
+                    $browse_button = (true === is_null($browse_button)) ? $prefix.'_browse' : $browse_button;
+
+                    return \View::make($view, array(
+                        'upload_handler' => \Config::get('plupload::plupload.upload_handler'),
+                        'browse_button_id' => $browse_button,
+                        'prefix' => $prefix,
+                        'handler_gate' => \Config::get('plupload::plupload.upload_handler_gate'),
+                        'max_file_size' => \Config::get('plupload::plupload.max_file_size'),
+                        'additional_data' => $additional_data,
+                    ));
+                }
+            )
+        ];
+    }
 }


### PR DESCRIPTION
- Updated for [laravel/framework 4.2.*](https://github.com/laravel/framework) 
- Updated for [rcrowe/TwigBridge 0.6.*](https://github.com/rcrowe/TwigBridge)
- Updated minimum PHP Version to 5.4 to stay aligned with laravel/framework
- src/Fojuth/Plupload/TwigExtension.php Had to be refactored for TwigBridge 0.6 changes

Upgrading to Laravel 4.2 required a bump to TwigBridge 0.6 due to other dependencies. I want to say 4.2 won't support 0.5 but I could be mistaken.

These changes are tested and working fine in my use case:

Laravel 4.2.*
TwigBridge 0.6.*

Ubuntu 14.04 (production server & local Homestead vagrant)
PHP 5.5.15RC1

**BC Breaking changes:** This PR will break anyone using Laravel 4.1.\* and TwigBridge 0.5.*
